### PR TITLE
Use merge queue directly instead of auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -90,4 +90,4 @@ jobs:
             --field "milestone=${MILESTONE_NUMBER}"
 
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto "$PR_URL"
+          gh pr merge --merge "$PR_URL"


### PR DESCRIPTION
Use merge queue directly instead of auto-merge for Dependabot PRs